### PR TITLE
Added a '+' before time loss

### DIFF
--- a/app/templates/components/ranking-list.hbs
+++ b/app/templates/components/ranking-list.hbs
@@ -12,9 +12,9 @@
       <td align="right">{{split.number}}</td>
 	    <td align="right">{{#link-to 'leg' split.leg}}{{split.code}}{{/link-to}}</td>
 	    <td align="right" title="Laufzeit">{{split.time}}</td>
-	    <td align="right" title="R&uuml;ckstand auf F&uuml;hrenden">{{split.overallBehind}}</td>
+	    <td align="right" title="R&uuml;ckstand auf F&uuml;hrenden">+ {{split.overallBehind}}</td>
 	    <td align="right" title="Rang">{{#if split.overallRank}}({{split.overallRank}}.){{/if}}</td>
-	    <td align="right" title="Abschnitts Zeit">{{split.split}}</td>
+	    <td align="right" title="Abschnitts Zeit">+ {{split.split}}</td>
 	    <td align="right" {{bind-attr title=split.timeLoss}} {{bind-attr class=view.errorClass}}>{{split.splitBehind}}</td>
 	    <td align="right" title="Abschnitts Rang">{{#if split.splitRank}}({{split.splitRank}}.){{/if}}</td>
   	  <td align="right" title="Performance Index">{{#if split.perfidx}}{{split.perfidx}}%{{/if}}</td>

--- a/app/templates/components/splits-entry.hbs
+++ b/app/templates/components/splits-entry.hbs
@@ -1,9 +1,9 @@
   <span class="split-entry-span">{{split.number}}</span>
   <span class="split-entry-span">{{#link-to 'leg' split.leg}}{{split.code}}{{/link-to}}</span>
   <span class="split-entry-span" title="Laufzeit">{{split.time}}</span>
-  <span class="split-entry-span" title="R&uuml;ckstand auf F&uuml;hrenden">{{split.overallBehind}}</span>
+  <span class="split-entry-span" title="R&uuml;ckstand auf F&uuml;hrenden">+ {{split.overallBehind}}</span>
   <span class="split-entry-span" title="Rang">{{#if split.overallRank}}({{split.overallRank}}.){{/if}}</span>
   <span class="split-entry-span" title="Abschnitts Zeit">{{split.split}}</span>
-  <span {{bind-attr title=split.timeLoss}} {{bind-attr class=view.errorClass}}>{{split.splitBehind}}</span>
+  <span {{bind-attr title=split.timeLoss}} {{bind-attr class=view.errorClass}}>+ {{split.splitBehind}}</span>
   <span class="split-entry-span" title="Abschnitts Rang">{{#if split.splitRank}}({{split.splitRank}}.){{/if}}</span>
   <span class="split-entry-span" title="Performance Index">{{#if split.perfidx}}{{split.perfidx}}%{{/if}}</span>


### PR DESCRIPTION
By adding a '+' before time losses it gets clearer to visitors which the time means.

BTW: why is the version on GH not the same as deployed to ol.zimaa.ch?